### PR TITLE
Include react app and grammars in vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,8 +1,10 @@
 .vscode/**
 .vscode-test/**
-out/test/**
+build/src/test/**
 
+react-help-app/**
 src/**
+grammars/**
 .gitignore
 .yarnrc
 vsc-extension-quickstart.md


### PR DESCRIPTION
The v1.8.3 vsix file for distribution was 32MB or so. This is partially because it packaged the grammars twice. This update fixes that, and also optimizes it further by not including the react app source code in the final package.